### PR TITLE
Feature/http-support - Add support for HTTP only HTTPRoutes

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Debug gatewayapi-operator",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${workspaceFolder}/cmd/main.go",
+            "env": {},
+            "args": []
+        }
+    ]
+}

--- a/doc/README.md
+++ b/doc/README.md
@@ -100,17 +100,50 @@ spec:
 kubectl get gateways -n <namespace du valgte på parentRefs over>
 ```
 
+### Konfigurering av redirect:
+https://gateway.envoyproxy.io/docs/tasks/traffic/http-redirect/ <br>
+(Gatewayapi-Operatoren oppretter ikke automatisk en redirect listener på Gatewayen, men dette er planlagt i en fremtidig release)
+
+For å konfigurere en redirect kan følgende eksempel benyttes:
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  annotations:
+    gatewayapi-operator.vitistack.io/enabled: "true"
+    gatewayapi-operator.vitistack.io/http: "true"
+  name: <name>_redirect
+  namespace: <namespace>
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: <navn på Gateway der eksisterende HTTPS HTTProute peker>
+      namespace: <namespace på Gateway>
+      sectionName: <fqdn>-http
+  hostnames:
+    - <fqdn>
+  rules:
+    - filters:
+        - type: RequestRedirect
+          requestRedirect:
+            scheme: https
+            statusCode: 301
+```
+
+
+### TLS mot backend - Konfigurering av BackendTLSPolicy:
+Eksempel kommer, men følgende dokumentasjon kan benyttes for å re-kryptere trafikk mot service som HTTPRouten peker på.
+https://gateway.envoyproxy.io/docs/api/gateway_api/backendtlspolicy/
+
+
+
+
 ### Kjente feil
 1. **Flere httproutes med forskjellige cluster-issuer annoteringer som peker på samme gateway er ikke mulig. Lag en ny gateway per cluster-issuer.**
 2. **Flere httproutes med forskjellige ipam.vitistack.io/zone annoteringer er ikke mulig. Lag en ny gateway per IPAM zone.**
 3. **Redirect og BackendTLSPolicy må konfigureres manuelt. Det er ikke implementert i GatewayAPI-Operatoren enda.**
 
 
-
-#### Konfigurering av redirect:
-https://gateway.envoyproxy.io/docs/tasks/traffic/http-redirect/ <br>
-(Gatewayapi-Operatoren oppretter ikke automatisk en redirect listener på Gatewayen, men dette er planlagt i en fremtidig release)
-
-#### TLS mot backend - Konfigurering av BackendTLSPolicy
-https://gateway.envoyproxy.io/docs/api/gateway_api/backendtlspolicy/
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -117,9 +117,7 @@ metadata:
   namespace: <namespace>
 spec:
   parentRefs:
-    - group: gateway.networking.k8s.io
-      kind: Gateway
-      name: <navn på Gateway der eksisterende HTTPS HTTProute peker>
+    - name: <navn på Gateway der eksisterende HTTPS HTTProute peker>
       namespace: <namespace på Gateway>
       sectionName: <fqdn>-http
   hostnames:

--- a/doc/TODO.md
+++ b/doc/TODO.md
@@ -3,3 +3,5 @@
 ### Add validation that a gateway does not already exist 
 
 ### Add support for http -> https redirection 
+
+### Log build version on startup

--- a/internal/controller/annotations.go
+++ b/internal/controller/annotations.go
@@ -5,6 +5,9 @@ const (
 	// Decides if we should ignore the httproute or not
 	// value type: bool
 	AnnotationUseHttprouteOperator = "gatewayapi-operator.vitistack.io/enabled"
+
+	// Decides if we should create the listener for HTTPRoute on port 80 without TLS
+	AnnotationHttpOnlyListener = "gatewayapi-operator.vitistack.io/http"
 	// AnnotationIPAMZone specifies the zone
 	// Value type: string
 	AnnotationIPAMZone = "ipam.vitistack.io/zone"

--- a/internal/controller/constants.go
+++ b/internal/controller/constants.go
@@ -23,6 +23,9 @@ const (
 	// httpsPort is the default HTTPS port
 	httpsPort = 443
 
+	// httpport is the default httpport
+	httpPort = 80
+
 	// tlsCertSuffix is the suffix for TLS certificate secret names
 	tlsCertSuffix = "-tls"
 

--- a/internal/controller/listener_manager.go
+++ b/internal/controller/listener_manager.go
@@ -29,6 +29,7 @@ func (r *HTTPRouteReconciler) collectListenersForGateway(
 
 	// Collect unique hostnames from HTTPRoutes that reference this Gateway
 	hostnameSet := make(map[string]bool)
+	httpHostnameSet := make(map[string]bool)
 	routeCount := 0
 	skippedCount := 0
 
@@ -39,6 +40,8 @@ func (r *HTTPRouteReconciler) collectListenersForGateway(
 			skippedCount++
 			continue
 		}
+		// Filter out all httproutes that are not enabled for this operator
+
 		if route.Annotations[AnnotationUseHttprouteOperator] != "true" {
 			skippedCount++
 			continue
@@ -56,7 +59,14 @@ func (r *HTTPRouteReconciler) collectListenersForGateway(
 				routeCount++
 				// Collect all hostnames from this route
 				for _, hostname := range route.Spec.Hostnames {
-					hostnameSet[string(hostname)] = true
+					// Add all httproutes that should be created on port 80 without TLS (redirect)
+					if route.Annotations[AnnotationHttpOnlyListener] == "true" {
+						httpHostnameSet[string(hostname)] = true
+					} else {
+						// Add all TLS 443 http(s)routes
+						hostnameSet[string(hostname)] = true
+
+					}
 					log.Info("Collected hostname", "hostname", hostname, "route", route.Name, "gateway", gatewayName)
 				}
 				break
@@ -65,20 +75,22 @@ func (r *HTTPRouteReconciler) collectListenersForGateway(
 	}
 
 	// Create HTTPS listeners for all collected hostnames
-	log.Info("Creating listeners from hostnames", "uniqueHostnames", len(hostnameSet))
+	log.Info("Creating listeners from hostnames", "uniqueHostnames", len(hostnameSet)+len(httpHostnameSet))
 	// listeners := make([]gatewayv1.Listener, 0, len(hostnameSet)*2)
-	listeners := make([]gatewayv1.Listener, 0, len(hostnameSet))
+	listeners := make([]gatewayv1.Listener, 0, len(hostnameSet)+len(httpHostnameSet))
 
 	for hostname := range hostnameSet {
 		httpsListener := r.createHTTPSListener(hostname, gatewayNamespace)
 		log.Info("Created HTTPS listener", "name", httpsListener.Name, "hostname", hostname)
 		listeners = append(listeners, httpsListener)
-		// httpListener := r.createHTTPListener(hostname)
-		// log.Info("Created HTTP listener", "name", httpListener.Name, "hostname", hostname)
-		// listeners = append(listeners, httpListener)
+
 	}
 
-	// TODO: maybe (?) call create redirect httproute function here
+	for httpHostname := range httpHostnameSet {
+		httpListener := r.createHTTPListener(httpHostname)
+		log.Info("Created HTTP listener", "name", httpListener.Name, "hostname", httpHostname)
+		listeners = append(listeners, httpListener)
+	}
 
 	log.Info("Collected listeners for Gateway",
 		"gateway", gatewayName,
@@ -131,26 +143,26 @@ func (r *HTTPRouteReconciler) createHTTPSListener(
 	}
 }
 
-// func (r *HTTPRouteReconciler) createHTTPListener(
-// 	hostname string,
-// ) gatewayv1.Listener {
-// 	// Use hostname as the listener section name
-// 	listenerName := gatewayv1.SectionName(hostname) + "-http"
-// 	hn := gatewayv1.Hostname(hostname)
-// 	fromAll := gatewayv1.NamespacesFromAll
+func (r *HTTPRouteReconciler) createHTTPListener(
+	hostname string,
+) gatewayv1.Listener {
+	// Use hostname as the listener section name
+	listenerName := gatewayv1.SectionName(hostname) + "-http"
+	hn := gatewayv1.Hostname(hostname)
+	fromAll := gatewayv1.NamespacesFromAll
 
-// 	return gatewayv1.Listener{
-// 		Name:     listenerName,
-// 		Protocol: gatewayv1.HTTPProtocolType,
-// 		Port:     httpPort,
-// 		Hostname: &hn,
-// 		AllowedRoutes: &gatewayv1.AllowedRoutes{
-// 			Namespaces: &gatewayv1.RouteNamespaces{
-// 				From: &fromAll,
-// 			},
-// 		},
-// 	}
-// }
+	return gatewayv1.Listener{
+		Name:     listenerName,
+		Protocol: gatewayv1.HTTPProtocolType,
+		Port:     httpPort,
+		Hostname: &hn,
+		AllowedRoutes: &gatewayv1.AllowedRoutes{
+			Namespaces: &gatewayv1.RouteNamespaces{
+				From: &fromAll,
+			},
+		},
+	}
+}
 
 // updateGatewayListeners updates the gateway's listeners based on all HTTPRoutes referencing it
 func (r *HTTPRouteReconciler) updateGatewayListeners(


### PR DESCRIPTION
Allows users to create a HTTP -> HTTPS redirect or configure a HTTP only HTTPRoute

Uses annotation
```
    gatewayapi-operator.vitistack.io/http: "true"
```
to specify that the listener should be HTTP and not do TLS.

Example is added to doc/README.md