### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-chart.yml
+++ b/.github/workflows/test-chart.yml
@@ -1,5 +1,8 @@
 name: Test Chart
 
+permissions:
+  contents: read
+
 on:
   push:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/NorskHelsenett/gatewayapi-operator/security/code-scanning/1](https://github.com/NorskHelsenett/gatewayapi-operator/security/code-scanning/1)

In general, this issue is fixed by adding an explicit `permissions` block to the workflow (either at the top level or per job) that grants only the minimal required scopes. This documents the intended permissions, prevents accidental escalation if org/repo defaults change, and satisfies the CodeQL rule.

For this specific workflow, none of the steps need to write to the repository or otherwise call GitHub APIs with write access. The minimal safe permissions are `contents: read`. To avoid changing existing functionality, we should add a workflow-level `permissions` block near the top of `.github/workflows/test-chart.yml`, under the `name:` and before `on:`. This will apply to all jobs (currently only `test-e2e`) and restrict the `GITHUB_TOKEN` to read-only repository contents access. No other code changes or imports are needed.

Concretely:
- Edit `.github/workflows/test-chart.yml`.
- Insert:

  ```yaml
  permissions:
    contents: read
  ```

  after line 1 (`name: Test Chart`) and before the existing `on:` block.
- No additional methods, definitions, or external dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
